### PR TITLE
Error Correction for Poorly Formatted Reports

### DIFF
--- a/DmarcRua/rua.cs
+++ b/DmarcRua/rua.cs
@@ -99,7 +99,8 @@ namespace DmarcRua
         fail,
         softfail,
         temperror,
-        permerror
+        permerror,
+        [XmlEnum("hardfail")] Hardfail = fail
     }
 
     [Serializable]
@@ -171,7 +172,8 @@ namespace DmarcRua
         trusted_forwarder,
         mailing_list,
         local_policy,
-        other
+        other,
+        [XmlEnum("")] Default = other
     }
 
     [Serializable]

--- a/DmarcRua/rua.xsd
+++ b/DmarcRua/rua.xsd
@@ -125,6 +125,7 @@ trusted_forwarder:  Message authentication failure was anticipated by
     <xs:enumeration value="mailing_list"/>
     <xs:enumeration value="local_policy"/>
     <xs:enumeration value="other"/>
+    <xs:enumeration value=""/>
   </xs:restriction>
 </xs:simpleType>
 
@@ -219,6 +220,8 @@ trusted_forwarder:  Message authentication failure was anticipated by
     <xs:enumeration value="temperror"/>
     <!-- "PermError" commonly implemented as "error" -->
     <xs:enumeration value="permerror"/>
+    <!-- "hardfail" should be handled as fail -->
+    <xs:enumeration value="hardfail"/>
   </xs:restriction>
 </xs:simpleType>
 

--- a/DmarcRuaTests/DmarcRua.Tests.csproj
+++ b/DmarcRuaTests/DmarcRua.Tests.csproj
@@ -5,12 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="Unit\DocomoGenerated.xml" />
-    <None Remove="Unit\InvalidReport.xml" />
-    <None Remove="Unit\SampleReport.xml" />
-  </ItemGroup>
-
-  <ItemGroup>
     <EmbeddedResource Include="Unit\InvalidReport.xml" />
     <EmbeddedResource Include="Unit\SampleReport.xml" />
     <EmbeddedResource Include="Unit\GoogleGenerated.xml" />

--- a/DmarcRuaTests/DmarcRua.Tests.csproj
+++ b/DmarcRuaTests/DmarcRua.Tests.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="Unit\DocomoGenerated.xml" />
     <None Remove="Unit\InvalidReport.xml" />
     <None Remove="Unit\SampleReport.xml" />
   </ItemGroup>
@@ -12,8 +13,9 @@
   <ItemGroup>
     <EmbeddedResource Include="Unit\InvalidReport.xml" />
     <EmbeddedResource Include="Unit\SampleReport.xml" />
-    <None Remove="Unit\GoogleGenerated.xml" />
     <EmbeddedResource Include="Unit\GoogleGenerated.xml" />
+    <EmbeddedResource Include="Unit\KddiGenerated.xml" />
+    <EmbeddedResource Include="Unit\DocomoGenerated.xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DmarcRuaTests/Unit/AggregateReportTests.cs
+++ b/DmarcRuaTests/Unit/AggregateReportTests.cs
@@ -70,7 +70,7 @@ namespace DmarcRua.Tests.Unit
         }
 
         [Test]
-        public void should_catch_poorly_formatted()
+        public void should_handle_poorly_formatted_report()
         {
             var assmebly = Assembly.GetExecutingAssembly();
             var reportStream = assmebly.GetManifestResourceStream("DmarcRua.Tests.Unit.KddiGenerated.xml");
@@ -82,7 +82,7 @@ namespace DmarcRua.Tests.Unit
         }
 
         [Test]
-        public void should_catch_another_poorly_formatted()
+        public void should_handle_another_poorly_formatted_report()
         {
             var assmebly = Assembly.GetExecutingAssembly();
             var reportStream = assmebly.GetManifestResourceStream("DmarcRua.Tests.Unit.DocomoGenerated.xml");

--- a/DmarcRuaTests/Unit/AggregateReportTests.cs
+++ b/DmarcRuaTests/Unit/AggregateReportTests.cs
@@ -68,5 +68,29 @@ namespace DmarcRua.Tests.Unit
 
             Assert.AreEqual(true, aggregate.ValidReport);
         }
+
+        [Test]
+        public void should_catch_poorly_formatted()
+        {
+            var assmebly = Assembly.GetExecutingAssembly();
+            var reportStream = assmebly.GetManifestResourceStream("DmarcRua.Tests.Unit.KddiGenerated.xml");
+
+            var aggregate = new AggregateReport();
+            aggregate.ReadAggregateReport(reportStream);
+
+            Assert.AreEqual(true, aggregate.ValidReport);
+        }
+
+        [Test]
+        public void should_catch_another_poorly_formatted()
+        {
+            var assmebly = Assembly.GetExecutingAssembly();
+            var reportStream = assmebly.GetManifestResourceStream("DmarcRua.Tests.Unit.DocomoGenerated.xml");
+
+            var aggregate = new AggregateReport();
+            aggregate.ReadAggregateReport(reportStream);
+
+            Assert.AreEqual(true, aggregate.ValidReport);
+        }
     }
 }

--- a/DmarcRuaTests/Unit/DocomoGenerated.xml
+++ b/DmarcRuaTests/Unit/DocomoGenerated.xml
@@ -1,0 +1,40 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<feedback>
+	<report_metadata>
+		<org_name>docomo.ne.jp</org_name>
+		<email>reporting@dmarc25.jp</email>
+		<report_id>0b345b52fe5fb3b7134eb27764cabd79</report_id>
+		<date_range>
+			<begin>1705363200</begin>
+			<end>1705449599</end>
+		</date_range>
+	</report_metadata>
+	<policy_published>
+		<adkim>r</adkim>
+		<domain>domain.tld</domain>
+		<aspf>r</aspf>
+		<p>reject</p>
+		<pct>100</pct>
+		<sp>reject</sp>
+	</policy_published>
+	<record>
+		<row>
+			<source_ip>175.173.163.47</source_ip>
+			<count>1</count>
+			<policy_evaluated>
+				<disposition>reject</disposition>
+				<dkim>fail</dkim>
+				<spf>fail</spf>
+			</policy_evaluated>
+		</row>
+		<identifiers>
+			<header_from>domain.tld</header_from>
+		</identifiers>
+		<auth_results>
+			<spf>
+				<domain>domain.tld</domain>
+				<result>hardfail</result>
+			</spf>
+		</auth_results>
+	</record>
+</feedback>

--- a/DmarcRuaTests/Unit/KddiGenerated.xml
+++ b/DmarcRuaTests/Unit/KddiGenerated.xml
@@ -1,0 +1,56 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<feedback>
+	<version>1.0</version>
+	<report_metadata>
+		<org_name>kddi.com</org_name>
+		<email>noreply-dmarc-support@kddi.com</email>
+		<extra_contact_info>https://support.kddi.com/dmarc</extra_contact_info>
+		<report_id>20240130122811787517</report_id>
+		<date_range>
+			<begin>1706585291</begin>
+			<end>1706585291</end>
+		</date_range>
+	</report_metadata>
+	<policy_published>
+		<domain>domain.tld</domain>
+		<adkim>r</adkim>
+		<aspf>r</aspf>
+		<p>reject</p>
+		<sp>reject</sp>
+		<pct>100</pct>
+		<fo>0</fo>
+	</policy_published>
+	<record>
+		<row>
+			<source_ip>3.112.248.198</source_ip>
+			<count>1</count>
+			<policy_evaluated>
+				<disposition>reject</disposition>
+				<dkim>fail</dkim>
+				<spf>fail</spf>
+				<reason>
+					<type></type>
+					<comment></comment>
+				</reason>
+			</policy_evaluated>
+		</row>
+		<identifiers>
+			<envelope_to>ezweb.ne.jp</envelope_to>
+			<envelope_from>gbhem.ORG</envelope_from>
+			<header_from>domain.tld</header_from>
+		</identifiers>
+		<auth_results>
+			<dkim>
+				<domain></domain>
+				<selector></selector>
+				<result>none</result>
+				<human_result>no signature data</human_result>
+			</dkim>
+			<spf>
+				<domain>gbhem.ORG</domain>
+				<scope>mfrom</scope>
+				<result>pass</result>
+			</spf>
+		</auth_results>
+	</record>
+</feedback>


### PR DESCRIPTION
Added some Error Correction for poorly formatted XML Reports. I have collected close to 1000 reports the last 7 months and ran all through the Parser. 

I saw 2 kinds of errors which would be nice to be able to handle. I know the errors is most likely to be on the "other end" - but still I would like to read the reports.

The errors:
1. empty value in PolicyOverrideType - I think it should read as other
2. hardfail in SPFResultType - I think it should be read as fail

I added 2 reports where I changed my domain to domain.tld else they are as I got them in the rua inbox.