### PR TITLE
Update to Clean the Strings for ASPF and ADKIM before returning them.

### DIFF
--- a/src/DmarcRua/rua.cs
+++ b/src/DmarcRua/rua.cs
@@ -46,7 +46,7 @@ namespace DmarcRua
 
         [XmlElement("version", Form = XmlSchemaForm.Unqualified)]
         public string Version { get; set; }
-        
+
         [XmlElement("extension", Form = XmlSchemaForm.Unqualified)]
         public ExtensionType Extension { get; set; }
     }
@@ -300,10 +300,15 @@ namespace DmarcRua
         public string Domain { get; set; }
 
         [XmlElement("adkim", Form = XmlSchemaForm.Unqualified)]
-        public AlignmentType? Adkim { get; set; }
+        public string AdkimRaw { get; set; }
+
+        public AlignmentType? Adkim => AdkimRaw.AlignmentTypeFromString();
 
         [XmlElement("aspf", Form = XmlSchemaForm.Unqualified)]
-        public AlignmentType? Aspf { get; set; }
+        public string AspfRaw { get; set; }
+
+        public AlignmentType? Aspf => AspfRaw.AlignmentTypeFromString();
+
 
         [XmlElement("p", Form = XmlSchemaForm.Unqualified)]
         public DispositionType P { get; set; }
@@ -354,5 +359,30 @@ namespace DmarcRua
     public class ExtensionType
     {
         [XmlAnyElement] public XmlElement[] Any { get; set; }
+    }
+
+
+    internal static class ValidationFunctions
+    {
+        internal static AlignmentType? AlignmentTypeFromString(this string alignmentType)
+        {
+            switch (alignmentType.CleanOutStringSpecials())
+            {
+                case "r":
+                    return AlignmentType.Relaxed;
+                case "s":
+                    return AlignmentType.Strict;
+                default:
+                    return null;
+            }
+        }
+
+        internal static string CleanOutStringSpecials(this string input)
+        {
+            input = input?.Trim().ToLower();
+            // Clean out any special characters from the string. 
+            return System.Text.RegularExpressions.Regex.Replace(input, "[^a-z0-9]", "");
+
+        }
     }
 }

--- a/src/DmarcRua/rua.xsd
+++ b/src/DmarcRua/rua.xsd
@@ -20,15 +20,7 @@
             <xs:element name="error" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
         </xs:choice>
     </xs:complexType>
-
-    <!-- Alignment mode (relaxed or strict) for DKIM and SPF. -->
-    <xs:simpleType name="AlignmentType">
-        <xs:restriction base="xs:string">
-            <xs:enumeration value="r"/>
-            <xs:enumeration value="s"/>
-        </xs:restriction>
-    </xs:simpleType>
-
+    
     <!-- The methods used to discovery the policy used during evaluation.
          Available values are "psl" and "treewalk"
     -->
@@ -77,9 +69,9 @@
             <!-- The domain at which the DMARC record was found. -->
             <xs:element name="domain" type="xs:string"/>
             <!-- The DKIM alignment mode. -->
-            <xs:element name="adkim" type="AlignmentType" minOccurs="0"/>
+            <xs:element name="adkim" type="xs:string" minOccurs="0"/>
             <!-- The SPF alignment mode. -->
-            <xs:element name="aspf" type="AlignmentType" minOccurs="0"/>
+            <xs:element name="aspf" type="xs:string" minOccurs="0"/>
             <!-- The policy to apply to messages from the domain. -->
             <xs:element name="p" type="DispositionType"/>
             <!-- The handling policy for non-existent subdomains-->


### PR DESCRIPTION
My Fixes for the Unclean Report from Comcast

Added a Validation Functions Static Class to maximize reusability for future scenarios where this may happen.

Fixes - #6 